### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/LoginTasks.php
+++ b/lib/Horde/LoginTasks.php
@@ -103,7 +103,8 @@ class Horde_LoginTasks
         /* Get last task run date(s). Array keys are app names, values are
          * last run timestamps. Special key '_once' contains list of
          * ONCE tasks previously run. */
-        $lasttask = $this->_backend->getLastRun();
+	$lasttask = $this->_backend->getLastRun();
+	$lasttask = $lasttask === false ? array() : $lasttask;
 
         /* Create time objects for today's date and last task run date. */
         $cur_date = getdate();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/LoginTasks/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/LoginTasks/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde LoginTasks Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/LoginTasks/LoginTasksTest.php
+++ b/test/Horde/LoginTasks/LoginTasksTest.php
@@ -22,7 +22,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 
-class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
+class Horde_LoginTasks_LoginTasksTest extends Horde_Test_Case
 {
     public function testTheTasksAreRun()
     {
@@ -315,7 +315,7 @@ class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
                 'Horde_LoginTasks_Stub_Notice',
             )
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'URL',
             (string) $tasks->runTasks()
         );
@@ -404,7 +404,7 @@ class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
             'url' => 'redirect'
         ));
         $tasks->displayTasks();
-        $this->assertContains(
+        $this->assertStringContainsString(
             'URL',
             (string) $tasks->runTasks(array('user_confirmed' => true))
         );
@@ -433,7 +433,7 @@ class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
                 'Horde_LoginTasks_Stub_NoticeTwo',
             )
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'URL',
             (string) $tasks->runTasks(array('url' => 'redirect'))
         );
@@ -455,7 +455,7 @@ class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
             ),
             $classes
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'URL',
             (string) $tasks->runTasks(array(
                 'confirmed' => array(
@@ -496,7 +496,7 @@ class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
             ),
             $classes
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'URL',
             (string) $tasks->runTasks(array('user_confirmed' => true))
         );
@@ -521,7 +521,7 @@ class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
             ),
             $classes
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'URL',
             (string) $tasks->runTasks(array(
                 'confirmed' => array(
@@ -553,7 +553,7 @@ class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
             ),
             $classes
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'URL',
             (string) $tasks->runTasks(array(
                 'confirmed' => array(
@@ -586,7 +586,7 @@ class Horde_LoginTasks_LoginTasksTest extends PHPUnit_Framework_TestCase
             ),
             $classes
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'redirect',
             (string) $tasks->runTasks(array('user_confirmed' => true))
         );

--- a/test/Horde/LoginTasks/Stubs.php
+++ b/test/Horde/LoginTasks/Stubs.php
@@ -43,6 +43,7 @@ class Horde_LoginTasks_Stub_Backend extends Horde_LoginTasks_Backend
     public function markLastRun()
     {
         $lasttasks = $this->getLastRun();
+	$lasttasks = $lasttasks === false ? array() : $lasttasks;
         $lasttasks['test'] = time();
         self::$lastRun = $lasttasks;
     }


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-logintasks/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Add 1011_php8.1.patch. https://salsa.debian.org/horde-team/php-horde-logintasks/-/blob/debian-sid/debian/patches/1011_php8.1.patch
